### PR TITLE
fix python/pip missing requirements in docker host, missing cat pictures

### DIFF
--- a/section_4/code/cd_pipeline/Jenkinsfile
+++ b/section_4/code/cd_pipeline/Jenkinsfile
@@ -100,7 +100,8 @@ def approve() {
 
 
 def runUnittests() {
-	sh "python section_4/code/cd_pipeline/tests/test_flask_app.py"
+	sh "pip3 install --no-cache-dir -r ./section_4/code/cd_pipeline/requirements.txt"
+	sh "python3 section_4/code/cd_pipeline/tests/test_flask_app.py"
 }
 
 

--- a/section_4/code/cd_pipeline/Jenkinsfile_part_2
+++ b/section_4/code/cd_pipeline/Jenkinsfile_part_2
@@ -36,7 +36,6 @@ pipeline {
 		stage("Test - UAT Stage") {
 			steps { runUAT(88) }
 		}
-
 	}
 }
 
@@ -69,12 +68,12 @@ def deploy(environment) {
 	sh "docker ps -f name=${containerName} -q | xargs --no-run-if-empty docker stop"
 	sh "docker ps -a -f name=${containerName} -q | xargs -r docker rm"
 	sh "docker run -d -p ${port}:5000 --name ${containerName} hands-on-jenkins/myapp:${BUILD_NUMBER}"
-
 }
 
 
 def runUnittests() {
-	sh "python section_4/code/cd_pipeline/tests/test_flask_app.py"
+	sh "pip3 install --no-cache-dir -r ./section_4/code/cd_pipeline/requirements.txt"
+	sh "python3 section_4/code/cd_pipeline/tests/test_flask_app.py"
 }
 
 

--- a/section_4/code/cd_pipeline/app.py
+++ b/section_4/code/cd_pipeline/app.py
@@ -5,18 +5,18 @@ app = Flask(__name__)
 
 # list of cat images
 images = [
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr05/15/9/anigif_enhanced-buzz-26388-1381844103-11.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr01/15/9/anigif_enhanced-buzz-31540-1381844535-8.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr05/15/9/anigif_enhanced-buzz-26390-1381844163-18.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr06/15/10/anigif_enhanced-buzz-1376-1381846217-0.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr03/15/9/anigif_enhanced-buzz-3391-1381844336-26.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr06/15/10/anigif_enhanced-buzz-29111-1381845968-0.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr03/15/9/anigif_enhanced-buzz-3409-1381844582-13.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr02/15/9/anigif_enhanced-buzz-19667-1381844937-10.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr05/15/9/anigif_enhanced-buzz-26358-1381845043-13.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr06/15/9/anigif_enhanced-buzz-18774-1381844645-6.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr06/15/9/anigif_enhanced-buzz-25158-1381844793-0.gif",
-    "http://ak-hdl.buzzfed.com/static/2013-10/enhanced/webdr03/15/10/anigif_enhanced-buzz-11980-1381846269-1.gif"
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-26383-1381845104-25.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-26358-1381845043-13.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-25329-1381845415-0.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-23859-1381845509-0.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-19708-1381845008-7.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-19667-1381844937-10.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-3409-1381844582-13.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-3391-1381844336-26.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-1376-1381846217-0.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-26390-1381844163-18.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-26388-1381844103-11.gif",
+    "http://www.catshaming.co.uk/wp-content/uploads/2014/11/anigif_enhanced-buzz-27162-1381845360-0.gif"
 ]
 
 @app.route('/')


### PR DESCRIPTION
@cirulls 

1. Seems that despite all the Docker talk, the actual steps are executed in the Jenkins host => python3/pip3 must be available in the host system AND requirements.txt needs to be installed (rather than simply hardcoding Flask in the pipeline)
2. Cat gifs are missing! 

Other observations:
- would be nice to update course materials and mention the python/pip requirement (just like maven is mentioned in earlier sections)
- alternatively it would be nice to simply update the pipeline to execute the steps in the Docker image where dependencies are available (otherwise we are just moving the 'dependency hell' from the app to the CI environment)
- when mounting /var/run/docker.sock (when running Jenkins itself in Docker and wanting to allow docker-in-docker), a running container with that socket won't properly map ports in the Jenkins docker but rather on the main host, so UAT won't work in that case.